### PR TITLE
feat: add MediaWatcher for tracking music/podcast/video playback

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -75,6 +75,15 @@
             android:exported="false"
             android:foregroundServiceType="dataSync" />
 
+        <service
+            android:name=".watcher.MediaWatcher"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+
         <!-- Category Time Widget -->
         <receiver
             android:name=".widget.CategoryTimeWidgetProvider"

--- a/mobile/src/main/java/net/activitywatch/android/OnboardingActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/OnboardingActivity.kt
@@ -130,6 +130,8 @@ class FeaturesFragment : Fragment() {
 
 
 class PermissionsFragment : Fragment() {
+    private var notificationSettingsOpened = false
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -161,6 +163,12 @@ class PermissionsFragment : Fragment() {
         val usagePermissionGranted = UsageStatsWatcher.isUsageAllowed(requireContext())
         val accessibilityPermissionGranted = UsageStatsWatcher.isAccessibilityAllowed(requireContext())
         val notificationPermissionGranted = MediaWatcher.isNotificationAccessGranted(requireContext())
+
+        // Auto-request notification access as part of onboarding (only once per fragment instance)
+        if (!notificationPermissionGranted && !notificationSettingsOpened) {
+            notificationSettingsOpened = true
+            startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+        }
 
         // Disable buttons if permissions granted
         view?.findViewById<Button>(R.id.btnGrantUsagePermission)?.isEnabled = !usagePermissionGranted

--- a/mobile/src/main/java/net/activitywatch/android/OnboardingActivity.kt
+++ b/mobile/src/main/java/net/activitywatch/android/OnboardingActivity.kt
@@ -17,6 +17,7 @@ import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
+import net.activitywatch.android.watcher.MediaWatcher
 import net.activitywatch.android.watcher.UsageStatsWatcher
 
 // enum for the onboarding pages
@@ -146,6 +147,10 @@ class PermissionsFragment : Fragment() {
         view.findViewById<Button>(R.id.btnGrantAccessibilityPermission).setOnClickListener {
             startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
         }
+        // Handle grant notification access (for media watcher)
+        view.findViewById<Button>(R.id.btnGrantNotificationPermission).setOnClickListener {
+            startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+        }
     }
 
     // When fragment is resumed, check if the permission has been granted
@@ -155,13 +160,16 @@ class PermissionsFragment : Fragment() {
         // Get current permission status
         val usagePermissionGranted = UsageStatsWatcher.isUsageAllowed(requireContext())
         val accessibilityPermissionGranted = UsageStatsWatcher.isAccessibilityAllowed(requireContext())
+        val notificationPermissionGranted = MediaWatcher.isNotificationAccessGranted(requireContext())
 
         // Disable buttons if permissions granted
         view?.findViewById<Button>(R.id.btnGrantUsagePermission)?.isEnabled = !usagePermissionGranted
         view?.findViewById<Button>(R.id.btnGrantAccessibilityPermission)?.isEnabled = !accessibilityPermissionGranted
+        view?.findViewById<Button>(R.id.btnGrantNotificationPermission)?.isEnabled = !notificationPermissionGranted
 
         // Set the checkbox/x mark based on the permission status
         view?.findViewById<ImageView>(R.id.checkmarkUsage)?.setImageResource(if(usagePermissionGranted) R.drawable.ic_checkmark else R.drawable.ic_x)
         view?.findViewById<ImageView>(R.id.checkmarkAccessibility)?.setImageResource(if(accessibilityPermissionGranted) R.drawable.ic_checkmark else R.drawable.ic_x)
+        view?.findViewById<ImageView>(R.id.checkmarkNotification)?.setImageResource(if(notificationPermissionGranted) R.drawable.ic_checkmark else R.drawable.ic_x)
     }
 }

--- a/mobile/src/main/java/net/activitywatch/android/watcher/MediaWatcher.kt
+++ b/mobile/src/main/java/net/activitywatch/android/watcher/MediaWatcher.kt
@@ -1,0 +1,233 @@
+package net.activitywatch.android.watcher
+
+import android.content.ComponentName
+import android.content.pm.PackageManager
+import android.media.MediaMetadata
+import android.media.session.MediaController
+import android.media.session.MediaSession
+import android.media.session.MediaSessionManager
+import android.media.session.PlaybackState
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import android.util.Log
+import net.activitywatch.android.RustInterface
+import org.json.JSONObject
+import org.threeten.bp.Instant
+
+/**
+ * Watches active media sessions (music, podcasts, video) and logs playback events
+ * to ActivityWatch using the NotificationListenerService API.
+ *
+ * Requires the user to grant "Notification Access" in system settings.
+ *
+ * Bucket: aw-watcher-android-media
+ * Event data: app, title, artist, album, state (playing/paused/stopped)
+ */
+class MediaWatcher : NotificationListenerService() {
+
+    companion object {
+        private const val TAG = "MediaWatcher"
+        private const val BUCKET_ID = "aw-watcher-android-media"
+        private const val BUCKET_TYPE = "media.playback"
+        // Heartbeat pulsetime: merge events within 60s (same track playing continuously)
+        private const val PULSETIME = 60.0
+
+        fun isNotificationAccessGranted(context: android.content.Context): Boolean {
+            val componentName = ComponentName(context, MediaWatcher::class.java)
+            val enabledListeners = android.provider.Settings.Secure.getString(
+                context.contentResolver,
+                "enabled_notification_listeners"
+            ) ?: return false
+            return enabledListeners.contains(componentName.flattenToString())
+        }
+    }
+
+    private var ri: RustInterface? = null
+    private var sessionManager: MediaSessionManager? = null
+    private val activeControllers = mutableMapOf<MediaSession.Token, MediaController>()
+    private val activeCallbacks = mutableMapOf<MediaSession.Token, MediaController.Callback>()
+
+    // Track last sent event to avoid duplicate heartbeats
+    private var lastEventKey: String? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.i(TAG, "MediaWatcher created")
+        ri = RustInterface(applicationContext)
+        ri?.createBucketHelper(BUCKET_ID, BUCKET_TYPE)
+
+        sessionManager = getSystemService(MEDIA_SESSION_SERVICE) as? MediaSessionManager
+        registerActiveSessionListener()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.i(TAG, "MediaWatcher destroyed")
+        unregisterAllCallbacks()
+    }
+
+    override fun onNotificationPosted(sbn: StatusBarNotification?) {
+        // We rely on MediaSessionManager for media tracking, not individual notifications.
+        // This callback is required by NotificationListenerService but we don't need it.
+    }
+
+    override fun onNotificationRemoved(sbn: StatusBarNotification?) {
+        // Not needed for media tracking.
+    }
+
+    /**
+     * Register a listener for active media session changes.
+     * This is called once on service creation and handles all session lifecycle.
+     */
+    private fun registerActiveSessionListener() {
+        val componentName = ComponentName(this, MediaWatcher::class.java)
+        try {
+            sessionManager?.addOnActiveSessionsChangedListener(
+                { controllers -> onActiveSessionsChanged(controllers) },
+                componentName
+            )
+            // Process currently active sessions
+            val activeSessions = sessionManager?.getActiveSessions(componentName)
+            if (activeSessions != null) {
+                onActiveSessionsChanged(activeSessions)
+            }
+        } catch (e: SecurityException) {
+            Log.e(TAG, "Notification access not granted: ${e.message}")
+        }
+    }
+
+    /**
+     * Called when the list of active media sessions changes.
+     * Registers callbacks for new sessions and cleans up stale ones.
+     */
+    private fun onActiveSessionsChanged(controllers: List<MediaController>?) {
+        if (controllers == null) return
+
+        val currentTokens = controllers.map { it.sessionToken }.toSet()
+
+        // Remove callbacks for sessions that are no longer active
+        val staleTokens = activeControllers.keys - currentTokens
+        for (token in staleTokens) {
+            val controller = activeControllers.remove(token)
+            val callback = activeCallbacks.remove(token)
+            if (controller != null && callback != null) {
+                controller.unregisterCallback(callback)
+                Log.d(TAG, "Unregistered callback for ${controller.packageName}")
+            }
+        }
+
+        // Register callbacks for new sessions
+        for (controller in controllers) {
+            val token = controller.sessionToken
+            if (token !in activeControllers) {
+                val callback = createMediaCallback(controller)
+                controller.registerCallback(callback)
+                activeControllers[token] = controller
+                activeCallbacks[token] = callback
+                Log.i(TAG, "Registered callback for ${controller.packageName}")
+
+                // Send initial state if already playing
+                val state = controller.playbackState
+                val metadata = controller.metadata
+                if (state != null && metadata != null) {
+                    handlePlaybackChange(controller, state, metadata)
+                }
+            }
+        }
+    }
+
+    /**
+     * Create a MediaController.Callback that logs playback state changes.
+     */
+    private fun createMediaCallback(controller: MediaController): MediaController.Callback {
+        return object : MediaController.Callback() {
+            override fun onPlaybackStateChanged(state: PlaybackState?) {
+                val metadata = controller.metadata ?: return
+                if (state != null) {
+                    handlePlaybackChange(controller, state, metadata)
+                }
+            }
+
+            override fun onMetadataChanged(metadata: MediaMetadata?) {
+                val state = controller.playbackState ?: return
+                if (metadata != null) {
+                    handlePlaybackChange(controller, state, metadata)
+                }
+            }
+
+            override fun onSessionDestroyed() {
+                val token = controller.sessionToken
+                activeControllers.remove(token)
+                activeCallbacks.remove(token)?.let { controller.unregisterCallback(it) }
+                Log.d(TAG, "Session destroyed for ${controller.packageName}")
+            }
+        }
+    }
+
+    /**
+     * Process a playback state or metadata change and send an event.
+     */
+    private fun handlePlaybackChange(
+        controller: MediaController,
+        state: PlaybackState,
+        metadata: MediaMetadata
+    ) {
+        val packageName = controller.packageName ?: return
+
+        val title = metadata.getString(MediaMetadata.METADATA_KEY_TITLE) ?: ""
+        val artist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST)
+            ?: metadata.getString(MediaMetadata.METADATA_KEY_ALBUM_ARTIST) ?: ""
+        val album = metadata.getString(MediaMetadata.METADATA_KEY_ALBUM) ?: ""
+
+        val playbackState = when (state.state) {
+            PlaybackState.STATE_PLAYING -> "playing"
+            PlaybackState.STATE_PAUSED -> "paused"
+            PlaybackState.STATE_STOPPED -> "stopped"
+            PlaybackState.STATE_BUFFERING -> "buffering"
+            else -> return // Ignore transitional states (none, connecting, etc.)
+        }
+
+        // Skip events with no useful metadata
+        if (title.isEmpty() && artist.isEmpty()) return
+
+        // Resolve app name from package
+        val appName = try {
+            val pm = applicationContext.packageManager
+            pm.getApplicationLabel(
+                pm.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            ).toString()
+        } catch (e: PackageManager.NameNotFoundException) {
+            packageName
+        }
+
+        // Build event data
+        val data = JSONObject().apply {
+            put("app", appName)
+            put("package", packageName)
+            put("title", title)
+            put("artist", artist)
+            put("album", album)
+            put("state", playbackState)
+        }
+
+        // Deduplicate: don't send identical heartbeats
+        val eventKey = "$packageName|$title|$artist|$playbackState"
+        if (eventKey == lastEventKey && playbackState == "playing") {
+            // Same track still playing — let heartbeat merging handle it
+            ri?.heartbeatHelper(BUCKET_ID, Instant.now(), 0.0, data, PULSETIME)
+            return
+        }
+        lastEventKey = eventKey
+
+        Log.i(TAG, "Media event: $playbackState — $artist - $title ($appName)")
+        ri?.heartbeatHelper(BUCKET_ID, Instant.now(), 0.0, data, PULSETIME)
+    }
+
+    private fun unregisterAllCallbacks() {
+        for ((token, controller) in activeControllers) {
+            activeCallbacks[token]?.let { controller.unregisterCallback(it) }
+        }
+        activeControllers.clear()
+        activeCallbacks.clear()
+    }
+}

--- a/mobile/src/main/java/net/activitywatch/android/watcher/MediaWatcher.kt
+++ b/mobile/src/main/java/net/activitywatch/android/watcher/MediaWatcher.kt
@@ -33,17 +33,19 @@ class MediaWatcher : NotificationListenerService() {
         private const val PULSETIME = 60.0
 
         fun isNotificationAccessGranted(context: android.content.Context): Boolean {
-            val componentName = ComponentName(context, MediaWatcher::class.java)
+            val flattenedComponent = ComponentName(context, MediaWatcher::class.java).flattenToString()
             val enabledListeners = android.provider.Settings.Secure.getString(
                 context.contentResolver,
                 "enabled_notification_listeners"
             ) ?: return false
-            return enabledListeners.contains(componentName.flattenToString())
+            // Parse colon-separated list and match exactly to avoid false positives
+            return enabledListeners.split(":").any { it == flattenedComponent }
         }
     }
 
     private var ri: RustInterface? = null
     private var sessionManager: MediaSessionManager? = null
+    private var activeSessionsListener: MediaSessionManager.OnActiveSessionsChangedListener? = null
     private val activeControllers = mutableMapOf<MediaSession.Token, MediaController>()
     private val activeCallbacks = mutableMapOf<MediaSession.Token, MediaController.Callback>()
 
@@ -82,10 +84,11 @@ class MediaWatcher : NotificationListenerService() {
     private fun registerActiveSessionListener() {
         val componentName = ComponentName(this, MediaWatcher::class.java)
         try {
-            sessionManager?.addOnActiveSessionsChangedListener(
-                { controllers -> onActiveSessionsChanged(controllers) },
-                componentName
-            )
+            val listener = MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
+                onActiveSessionsChanged(controllers)
+            }
+            activeSessionsListener = listener
+            sessionManager?.addOnActiveSessionsChangedListener(listener, componentName)
             // Process currently active sessions
             val activeSessions = sessionManager?.getActiveSessions(componentName)
             if (activeSessions != null) {
@@ -224,6 +227,13 @@ class MediaWatcher : NotificationListenerService() {
     }
 
     private fun unregisterAllCallbacks() {
+        // Remove the active sessions listener to prevent leaks
+        activeSessionsListener?.let { listener ->
+            sessionManager?.removeOnActiveSessionsChangedListener(listener)
+        }
+        activeSessionsListener = null
+
+        // Remove all per-controller callbacks
         for ((token, controller) in activeControllers) {
             activeCallbacks[token]?.let { controller.unregisterCallback(it) }
         }

--- a/mobile/src/main/res/layout/fragment_permissions.xml
+++ b/mobile/src/main/res/layout/fragment_permissions.xml
@@ -115,5 +115,49 @@
             android:layout_height="wrap_content"
             android:text="Grant" />
     </LinearLayout>
+
+    <com.google.android.material.divider.MaterialDivider
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginVertical="10dp"/>
+
+    <!-- Notification Access Permission (for Media Watcher) -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Notification Access"
+        android:textSize="16sp"/>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <ImageView
+            android:id="@+id/checkmarkNotification"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:src="@drawable/ic_x"
+            android:paddingEnd="10dp"/>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="(optional) Allow tracking media playback (music, podcasts, videos)."
+                android:paddingTop="8dp"/>
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/btnGrantNotificationPermission"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Grant" />
+    </LinearLayout>
     </LinearLayout>
 </LinearLayout>

--- a/mobile/src/main/res/layout/fragment_permissions.xml
+++ b/mobile/src/main/res/layout/fragment_permissions.xml
@@ -138,7 +138,9 @@
             android:layout_width="30dp"
             android:layout_height="30dp"
             android:src="@drawable/ic_x"
-            android:paddingEnd="10dp"/>
+            android:paddingEnd="10dp"
+            android:contentDescription=""
+            android:importantForAccessibility="no"/>
 
         <LinearLayout
             android:layout_width="0dp"


### PR DESCRIPTION
## Summary

Implements a media watcher that tracks music, podcast, and video playback on Android using the `NotificationListenerService` + `MediaSessionManager` APIs (Option 1 from #5).

### What it does
- **MediaWatcher.kt** — `NotificationListenerService` that detects active media sessions, subscribes to `MediaController.Callback` for real-time state/metadata changes, and logs heartbeat events
- **Bucket**: `aw-watcher-android-media` (type: `media.playback`)
- **Event data**: `app`, `package`, `title`, `artist`, `album`, `state` (playing/paused/stopped/buffering)
- **Onboarding**: Adds optional "Notification Access" permission to the permissions page

### How it works
1. Android starts the `NotificationListenerService` when the user grants Notification Access
2. `MediaSessionManager.addOnActiveSessionsChangedListener` tracks session lifecycle
3. For each active session, a `MediaController.Callback` fires on metadata/playback state changes
4. Events are sent via `RustInterface.heartbeatHelper()` with 60s pulsetime (continuous playback merges)
5. Deduplication prevents flooding identical heartbeats

### Permission required
User must enable "Notification Access" for ActivityWatch in system settings (same flow as Last.fm scrobbling apps). This is optional — the app works fine without it, just without media tracking.

### Files changed
| File | Change |
|------|--------|
| `MediaWatcher.kt` | New — core media watcher implementation |
| `AndroidManifest.xml` | Added service declaration |
| `OnboardingActivity.kt` | Added notification permission check/button |
| `fragment_permissions.xml` | Added notification access UI section |

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracks media playback to log active media sessions and playback events.
  * Adds a Notification Access permission request in onboarding with a Grant button and status indicator.
  * Adds a Notification Access section to the app permissions screen so users can view and grant notification access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->